### PR TITLE
Chart contains template spec with securityContext

### DIFF
--- a/chart/kubeftpd/templates/deployment.yaml
+++ b/chart/kubeftpd/templates/deployment.yaml
@@ -32,8 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.controller.securityContext | nindent 8 }}
       containers:
       - name: manager
         image: {{ include "kubeftpd.controller.image" . }}


### PR DESCRIPTION
Having securityContext within deployment template object causes this error running on k3s version v1.31.12+k3s1:

```
Release "kubeftpd" does not exist. Installing it now.
Error: failed to create typed patch object (ftp/kubeftpd-controller-manager; apps/v1, Kind=Deployment): .spec.template.spec.securityContext.allowPrivilegeEscalation: field not declared in schema
```

As the securityContext is set in the container spec for the deployment this code isn't needed.

# Pull Request

## Description

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security improvement

## Related Issues

<!-- Link to related issues using "Fixes #123" or "Closes #123" -->

## Changes Made

<!-- Describe what changes were made and why -->

### Code Changes

Removes `.spec.template.spec.securityContext` object from `chart/kubeftpd/templates/deployment.yaml`  as this field doesn't exist in the schema.

### Configuration Changes
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Environment
- [x] Local development environment
- [ ] Docker Compose setup
- [ ] Kind/Minikube cluster
- [ ] Cloud Kubernetes cluster

### Tests Performed
- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] E2E tests pass (`make test-e2e`)
- [ ] Linting passes (`make lint`)
- [ ] Security scan passes (`make security-scan`)
- [ ] Manual FTP testing completed

### New Tests Added
- [ ] Unit tests for new functionality
- [ ] Integration tests for new functionality
- [ ] E2E tests for new functionality
- [ ] No new tests (explain why)

## Security Considerations

<!-- If this PR has security implications, describe them -->

- [ ] This PR does not introduce security risks
- [ ] This PR includes security improvements
- [x] This PR requires security review

## Documentation

<!-- Check all that apply -->

- [ ] Updated README.md
- [ ] Updated API documentation
- [ ] Updated deployment documentation
- [ ] Added inline code comments
- [x] No documentation changes needed

## Backwards Compatibility

<!-- Describe any backwards compatibility considerations -->

- [x] This change is backwards compatible
- [ ] This change requires migration steps (documented below)
- [ ] This change breaks existing functionality (documented below)

### Migration Steps
<!-- If backwards compatibility is broken, describe migration steps -->

## Deployment Notes

<!-- Any special deployment considerations -->

- [ ] Requires CRD updates
- [ ] Requires RBAC changes
- [ ] Requires configuration changes
- [x] No special deployment requirements

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Check all items before submitting -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

<!--
By submitting this pull request, I confirm that:
- I have read and agree to the project's contributing guidelines
- I have tested my changes thoroughly
- I understand that this will be publicly available and may be reviewed by anyone
-->
